### PR TITLE
feat: show blinking news banners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1477,9 +1477,13 @@ const GoalChecklistModal = ({ goals, onClose }) => {
 
 const HomeScreen = ({ user, onNavigate, notifications, onSelectNotification }) => {
   const upcomingMatches = mockMatchHistory.filter(m => m.status === 'upcoming');
-  const [modal, setModal] = React.useState(null); 
+  const [modal, setModal] = React.useState(null);
   const [selectedItem, setSelectedItem] = React.useState(null);
   const [showMiniDojo, setShowMiniDojo] = React.useState(false);
+  const newsBanners = [
+    '🔔 새로운 소식: 정승연님으로부터 새로운 댓글이 달렸습니다',
+    '🔔 새로운 소식: 이정연님으로부터 좋아요를 받았습니다',
+  ];
 
   const openModal = (type, item = null) => { setModal(type); setSelectedItem(item); };
   const closeModal = () => { setModal(null); setSelectedItem(null); };
@@ -1491,6 +1495,8 @@ const HomeScreen = ({ user, onNavigate, notifications, onSelectNotification }) =
         case 'new_request': return `${opponentName}님으로부터 새로운 대련 신청이 도착했습니다.`;
         case 'declined': return `${opponentName}님이 대련을 거절했습니다.`;
         case 'changed': return `${opponentName}님이 대련 변경을 신청했습니다.`;
+        case 'comment': return `${opponentName}님으로부터 새로운 댓글이 달렸습니다.`;
+        case 'like': return `${opponentName}님으로부터 좋아요를 받았습니다.`;
         default: return `${opponentName}님으로부터 새로운 알림이 도착했습니다.`;
     }
   };
@@ -1546,6 +1552,14 @@ const HomeScreen = ({ user, onNavigate, notifications, onSelectNotification }) =
         </div>
 
         <div className="space-y-2">
+            {newsBanners.map((msg, idx) => (
+                <Card
+                    key={idx}
+                    className="bg-yellow-400/40 border-yellow-500/50 text-black animate-blink"
+                >
+                    <p className="text-sm font-bold whitespace-nowrap">{msg}</p>
+                </Card>
+            ))}
             {notifications.map(notification => (
                 <Card key={notification.id} onClick={() => onSelectNotification(notification)} className="bg-red-900/40 border-red-500/50 animate-pulse hover:bg-red-900/60 cursor-pointer">
                     <div className="flex items-center gap-3">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,17 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        blink: {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0' },
+        },
+      },
+      animation: {
+        blink: 'blink 2s ease-in-out infinite',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- replace scrolling marquee with custom blink animation in Tailwind config
- show two fixed yellow news banners with bell emoji for comment and like updates on the home screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897644fadc08330943b514f5f038429