### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
+# Keep current branch-specific ignore entry
 codex/update-first-banner-text-and-layout-ieour9
+
+# Dependencies
+node_modules/
+
+# Build outputs
+*.log


### PR DESCRIPTION
### Motivation
- Prevent `node_modules/` from appearing as untracked files and add a minimal `*.log` ignore rule while preserving the existing branch-specific ignore entry.

### Description
- Updated `.gitignore` to keep the existing `codex/update-first-banner-text-and-layout-ieour9` entry and add `node_modules/` and `*.log` ignore patterns.

### Testing
- Ran `npm run build`, which failed due to an unrelated preexisting parse error in `src/App.tsx` (`Unexpected "const"` near line ~270), indicating the `.gitignore` change did not introduce the build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0675845f0833086f83e4d346c5d19)